### PR TITLE
Support for GraphQL

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,9 +7,12 @@ val scala3Version = "3.7.0"
 ThisBuild / dynverVTagPrefix  := false
 ThisBuild / dynverSeparator   := "-"
 ThisBuild / scalaVersion      := scala3Version
-ThisBuild / semanticdbEnabled := true
+ThisBuild / semanticdbEnabled := !true
 ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
 ThisBuild / resolvers ++= Dependencies.projectResolvers
+
+logLevel := Level.Debug
+
 
 lazy val root = project
   .enablePlugins(BuildInfoPlugin, JavaAgent, JavaAppPackaging, LauncherJarPlugin, DockerPlugin)
@@ -23,7 +26,7 @@ lazy val root = project
     scalaVersion := scala3Version,
     libraryDependencies ++= {
       zio ++ db ++ scheduler ++
-        json ++ jwt ++ jsoup ++ ical4j ++ enumeratum ++ playwright
+        json ++ jwt ++ jsoup ++ ical4j ++ enumeratum ++ playwright ++ caliban
     },
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
     scalacOptions ++= Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   object Versions {
     val circe: Version         = "0.14.13"
     val doobie: Version        = "1.0.0-RC9"
-    val flyway: Version        = "11.9.0"
+    val flyway: Version        = "11.9.1"
     val ical4j: Version        = "4.1.1"
     val log4cats: Version      = "2.7.1"
     val postgresql: Version    = "42.7.6"
@@ -24,6 +24,7 @@ object Dependencies {
     val zioMetrics: Version    = "2.3.1"
     val zioPrelude: Version    = "1.0.0-RC40+6-91127e50-SNAPSHOT"
     val zioSchema: Version     = "1.7.2"
+    val caliban: Version       = "2.10.0"
   }
 
   lazy val zio: Modules = Seq(
@@ -98,6 +99,13 @@ object Dependencies {
   lazy val playwright: Modules = Seq(
     "com.microsoft.playwright" % "playwright" % "1.52.0"
   )
+
+  lazy val caliban: Modules = Seq(
+    "com.github.ghostdogpr" %% "caliban",
+    "com.github.ghostdogpr" %% "caliban-tracing",
+    "com.github.ghostdogpr" %% "caliban-quick",
+    "com.github.ghostdogpr" %% "caliban-zio-http"
+  ).map(_ % Versions.caliban)
 
   lazy val json: Modules = Seq(
     "io.circe" %% "circe-core",

--- a/src/main/scala/si/ogrodje/goo/graphql/GraphQLAPI.scala
+++ b/src/main/scala/si/ogrodje/goo/graphql/GraphQLAPI.scala
@@ -1,0 +1,48 @@
+package si.ogrodje.goo.graphql
+
+import caliban.*
+import caliban.quick.*
+import caliban.schema.Schema.auto.*
+import caliban.schema.ArgBuilder.auto.*
+import caliban.schema.SchemaDerivation
+import zio.*
+
+import java.time.OffsetDateTime
+import zio.http.URL
+import caliban.Value
+import si.ogrodje.goo.models.{Event, EventID}
+import caliban.schema.Schema
+
+object GraphQLAPI:
+  private given lowURLSchema: Schema[Any, zio.http.URL] =
+    Schema.stringSchema.contramap[zio.http.URL](p => p.toString)
+  private given eventSchema: Schema[Any, Event]         = Schema.gen
+
+  object customSchema extends SchemaDerivation[Any]
+
+  private final case class Queries(
+    events: Task[List[Event]]
+    // event: EventID => UIO[Option[Event]]
+  ) derives customSchema.SemiAuto
+  // object Queries:
+  //  given schema: Schema[Queries] = DeriveSchema.gen
+
+  private final case class Mutations(
+    hideEvent: EventID => UIO[Boolean],
+    promoteEvent: EventID => UIO[Boolean]
+  )
+
+  case class EventArgs(id: EventID)
+
+  private val queries = Queries(
+    events = ZIO.succeed(List.empty[Event])
+    // event = id => ZIO.succeed(None)
+  )
+
+  private val mutations = Mutations(
+    hideEvent = id => ZIO.succeed(true),
+    promoteEvent = id => ZIO.succeed(true)
+  )
+
+  // implicit val queriesSchema: Schema[Queries] = Schema.gen
+  val api: GraphQL[Any] = graphQL(RootResolver(queries /*, mutations */ ))

--- a/src/main/scala/si/ogrodje/goo/models/Meetup.scala
+++ b/src/main/scala/si/ogrodje/goo/models/Meetup.scala
@@ -28,7 +28,7 @@ final case class Meetup(
 )
 
 object Meetup:
-  given Schema[URL] = Schema
+  given urlSchema: Schema[URL] = Schema
     .primitive[String]
     .transform(
       str => URL.decode(str).toOption.get,

--- a/src/main/scala/si/ogrodje/goo/server/Keycloak.scala
+++ b/src/main/scala/si/ogrodje/goo/server/Keycloak.scala
@@ -65,11 +65,11 @@ object Keycloak:
 
   def live: ZLayer[Client, Throwable, Keycloak] = ZLayer.scoped:
     for
-      keycloakConfig @ (endpoint, realm) <- AppConfig.keycloakConfig
-      _                                  <- logInfo(s"Connecting with config: $keycloakConfig")
-      client                             <- serviceWith[Client](_.url(endpoint.addPath(s"/realms/$realm")))
-      certsRef                           <- Ref.make(Certs.empty)
-      _                                  <- collectCerts(client).flatMap(certsRef.set)
+      (endpoint, realm) <- AppConfig.keycloakConfig
+      _                 <- logInfo(s"Connecting to keycloak $endpoint with realm $realm")
+      client            <- serviceWith[Client](_.url(endpoint.addPath(s"/realms/$realm")))
+      certsRef          <- Ref.make(Certs.empty)
+      _                 <- collectCerts(client).flatMap(certsRef.set)
 
       reloadFib <-
         collectCerts(client)


### PR DESCRIPTION
This PR adds support for [GraphQL](https://graphql.org/) via [Caliban](https://zio.dev/ecosystem/community/caliban/).

Note to self. Currently, PR crashes the compiler. Likely due to a crash between ZIO HTTP and Caliban Schema / encoders-decoders, specifically for URL decoding.